### PR TITLE
URI Change to GUID; Tests for IObjects and BHoMObjects (PR #41)

### DIFF
--- a/RDF_Engine/Query/IndividualId.cs
+++ b/RDF_Engine/Query/IndividualId.cs
@@ -42,14 +42,18 @@ namespace BH.Engine.Adapters.RDF
             // If it is an IObject, simply use BHoM's Hash method.
             IObject iObject = individual as IObject;
             if (iObject != null)
-                return BH.Engine.Base.Query.Hash(iObject);
+            {
+                string hash = BH.Engine.Base.Query.Hash(iObject);
+                return GuidFromString(hash).ToString();
 
-            // Otherwise, obtain a static, repeatable Hash by serializing the object, encoding it in Base64, and then computing a hash of the resulting string.
-            // This is slow but should only happen in edge cases.
-            string base64Serialized = Convert.ToBase64JsonSerialized(individual);
-            string base64SerializedHash = Query.SHA256Hash(base64Serialized);
+            }
 
-            return base64SerializedHash;
+            BHoMObject bHoMObject = individual as BHoMObject;
+            if (bHoMObject != null)
+                return bHoMObject.BHoM_Guid.ToString();
+
+            Log.RecordError("Could not query the ID for an individual.");
+            return null;
         }
     }
 }

--- a/RDF_Engine/Query/IndividualId.cs
+++ b/RDF_Engine/Query/IndividualId.cs
@@ -39,6 +39,10 @@ namespace BH.Engine.Adapters.RDF
             if (individual == null)
                 return null;
 
+            BHoMObject bHoMObject = individual as BHoMObject;
+            if (bHoMObject != null)
+                return bHoMObject.BHoM_Guid.ToString();
+
             // If it is an IObject, simply use BHoM's Hash method.
             IObject iObject = individual as IObject;
             if (iObject != null)
@@ -47,10 +51,6 @@ namespace BH.Engine.Adapters.RDF
                 return GuidFromString(hash).ToString();
 
             }
-
-            BHoMObject bHoMObject = individual as BHoMObject;
-            if (bHoMObject != null)
-                return bHoMObject.BHoM_Guid.ToString();
 
             Log.RecordError("Could not query the ID for an individual.");
             return null;

--- a/RDF_Engine/RDF_Engine.csproj
+++ b/RDF_Engine/RDF_Engine.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="dotNetRDF" Version="2.7.5" />
+    <PackageReference Include="Flurl" Version="3.0.7" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
     <PackageReference Include="System.CodeDom" Version="7.0.0" />
   </ItemGroup>

--- a/RDF_Tests/RDF_Tests.csproj
+++ b/RDF_Tests/RDF_Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="CompareNETObjects" Version="4.78.0" />
     <PackageReference Include="dotNetRDF" Version="2.7.5" />
     <PackageReference Include="FluentAssertions" Version="6.9.0" />
+    <PackageReference Include="Flurl" Version="3.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />

--- a/RDF_Tests/ToTTLTests.cs
+++ b/RDF_Tests/ToTTLTests.cs
@@ -47,7 +47,6 @@ using BH.Engine.Base;
 using Convert = BH.Engine.Adapters.TTL.Convert;
 using BH.Engine.Adapters.TTL;
 
-
 namespace BH.Test.RDF
 {
     public class ToTTLTests : Test
@@ -399,7 +398,8 @@ namespace BH.Test.RDF
             CSharpGraph cSharpGraph = Compute.CSharpGraph(new List<object>() { room }, m_ontologySettings);
             string TTLGraph = cSharpGraph.ToTTL();
 
-            Assert.IsTrue(TTLGraph.Contains(room.BHoM_Guid.ToString()));
+            string roomUrl = Flurl.Url.Combine(cSharpGraph.OntologySettings.ABoxSettings.IndividualsBaseAddress, room.BHoM_Guid.ToString());
+            Assert.IsTrue(TTLGraph.Contains(roomUrl.ToLower()));
 
             var res = Convert.FromTTL(TTLGraph);
             var obj = res.Item1.First();
@@ -431,7 +431,8 @@ namespace BH.Test.RDF
             string hash = BH.Engine.Base.Query.Hash(iObject);
             string nurbsGuid = Engine.Adapters.RDF.Query.GuidFromString(hash).ToString();
 
-            Assert.IsTrue(TTLGraph.Contains(nurbsGuid));
+            string nurbsUrl = Flurl.Url.Combine(cSharpGraph.OntologySettings.ABoxSettings.IndividualsBaseAddress, nurbsGuid.ToString());
+            Assert.IsTrue(TTLGraph.Contains(nurbsUrl.ToLower()));
 
             var res = Convert.FromTTL(TTLGraph);
             var obj = res.Item1.First();


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #41 

Changed the composition of Individuals URI from Hash to GUID
Created new Tests in ToTTLTests to check the new URI for IObjects, BHoMObjects and non serialized IGeometry Objects.
