### PR TITLE
RDF_Engine: fix missing `not` in `BH.Engine.Adapters.RDF.Create.BasicGraphSettings()`

### DIFF
--- a/GraphDB_Engine/GraphDB_Engine.csproj
+++ b/GraphDB_Engine/GraphDB_Engine.csproj
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot;  &quot;$(SolutionDir)Build\&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)$(TargetFileName)&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y" />
+    <Exec Command="if not &quot;$(ConfigurationName)&quot; == &quot;Test&quot; (xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;$(SolutionDir)Build\&quot; /Y)&#xD;&#xA;if not &quot;$(ConfigurationName)&quot; == &quot;Test&quot; (xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y)" />
   </Target>
 
 </Project>

--- a/RDF_Engine/Create/BasicGraphSettings.cs
+++ b/RDF_Engine/Create/BasicGraphSettings.cs
@@ -38,9 +38,8 @@ namespace BH.Engine.Adapters.RDF
         [Input("ontologyDescription", "Sets the description of the ontology.")]
         [Input("tBoxURI", "The base address where the Ontology definition for Custom Types will be hosted. Custom Types are produced when computing an ontology that includes BHoM CustomObjects.")]
         [Input("aBoxURI", "The base address where the individuals will be hosted.")]
-        [Input("serializeGeoToBase64", "(defaults to false) If true, geometrical Types will be considered as Classes, and therefore Object Properties." +
-            "Otherwise, geometrical types are considered as a DataType of type Base64Serialized, and the geometry is encoded as a Data Property.")]
-
+        [Input("serializeGeoToBase64", "(defaults to false) If true, geometrical types are considered as a DataType of type Base64Serialized, and the geometry is encoded as a Data Property." +
+            "Otherwise, geometrical Types will be considered as Classes (i.e. their own type), and therefore are included as Object Properties.")]
         public static GraphSettings BasicGraphSettings(string ontologyTitle, string ontologyDescription, string tBoxURI, string aBoxURI, bool serializeGeoToBase64 = false)
         {
             return new GraphSettings()
@@ -48,7 +47,7 @@ namespace BH.Engine.Adapters.RDF
                 TBoxSettings = new TBoxSettings()
                 {
                     CustomObjectTypesBaseAddress = tBoxURI,
-                    GeometryAsOntologyClass = serializeGeoToBase64
+                    GeometryAsOntologyClass = !serializeGeoToBase64
                 },
                 ABoxSettings = new ABoxSettings()
                 {

--- a/TTL_Engine/TTL_Engine.csproj
+++ b/TTL_Engine/TTL_Engine.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;$(SolutionDir)Build\&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y" />
+    <Exec Command="if not &quot;$(ConfigurationName)&quot; == &quot;Test&quot; xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;$(SolutionDir)Build\&quot; /Y&#xD;&#xA;if not &quot;$(ConfigurationName)&quot; == &quot;Test&quot; xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y" />
   </Target>
 
 </Project>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #78

<!-- Add short description of what has been fixed -->
Adds a missing "not" in the `BH.Engine.Adapters.RDF.Create.BasicGraphSettings()` method that creates the settings, which caused wrong behaviour downstream.

### Test files
<!-- Link to test files to validate the proposed changes -->
See #78.
